### PR TITLE
keyof exercise - allowing to only pass the value type exact as field's value type we filter out

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Discover all the challenges by running `npm run` in your console. Here's the lis
 - `npm run test:only-one`
 - `npm run test:new-skills`
 - `npm run test:constraints`
+- `npm run test:type-operator`
 
 ## 🙌 Contributors welcomed!
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test:this-or-that": "tsc src/this-or-that/this-or-that.ts && vitest src/this-or-that",
     "test:only-one": "tsc src/only-one/only-one.ts && vitest src/only-one",
     "test:new-skills": "tsc src/new-skills/new-skills.ts && vitest src/new-skills",
-    "test:constraints": "tsc src/constraints/constraints.ts && vitest src/constraints"
+    "test:constraints": "tsc src/constraints/constraints.ts && vitest src/constraints",
+    "test:type-operator": "tsc src/type-operator/type-operator.ts && vitest src/type-operator"
   },
   "repository": {
     "type": "git",

--- a/src/type-operator/type-operator.test.js
+++ b/src/type-operator/type-operator.test.js
@@ -1,0 +1,11 @@
+import { test, expect } from 'vitest';
+import { filterByProperty, filteredBooksByAuthor, filteredVideosByLength } from './type-operator';
+
+
+  test('should return 1 book authored by Philip K. Dick', () => {
+    expect(filteredBooksByAuthor.length).toBe(1);
+  });
+
+  test('should return only some specific videos', () => {
+    expect(filteredVideosByLength.length).toBe(2);
+  });

--- a/src/type-operator/type-operator.ts
+++ b/src/type-operator/type-operator.ts
@@ -4,7 +4,7 @@
  * Utility Types
  * ------------------
  *
- * Goal: Now we can add wrong value types as parameter to the function. Let's fix it by using on of the type operators.
+ * Goal: Now we can add wrong value types as parameter to the function. Let's fix it by using one of the type operators.
  *
  * Hint: https://www.typescriptlang.org/docs/handbook/2/keyof-types.html
  */

--- a/src/type-operator/type-operator.ts
+++ b/src/type-operator/type-operator.ts
@@ -1,0 +1,58 @@
+/*
+ * Przeprogramowani.ts - https://przeprogramowani.pl/typescript/
+ *
+ * Utility Types
+ * ------------------
+ *
+ * Goal: Now we can add wrong value types as parameter to the function. Let's fix it by using on of the type operators.
+ *
+ * Hint: https://www.typescriptlang.org/docs/handbook/2/keyof-types.html
+ */
+
+interface IdentifiableItem {
+  id: number;
+  name: string;
+}
+
+interface Book extends IdentifiableItem {
+  author: string;
+}
+
+interface Video extends IdentifiableItem {
+  length: number;
+}
+
+const books: Book[] = [
+  { id: 1, name: 'Our Friends from Frolix 8', author: 'Philip K. Dick' },
+  {
+    id: 2,
+    name: 'When: The Scientific Secrets of Perfect Timing',
+    author: 'Daniel H. Pink'
+  },
+  {
+    id: 3,
+    name: 'Total Recall: My Unbelievably True Life Story',
+    author: 'John Doe'
+  },
+  { id: 4, name: 'Wyloguj swój mózg', author: 'Anders Hansen' }
+];
+
+const videos: Video[] = [
+  { id: 1, name: 'Ciekawostki o typach', length: 17 },
+  { id: 2, name: 'Refaktoryzacja JS do TS', length: 15 },
+  { id: 3, name: 'TypeScript na Backendzie', length: 13 },
+  { id: 4, name: 'TypeScript i Frameworki Front-Endowe', length: 19 },
+  { id: 5, name: 'Poznaj TypeScript', length: 15 }
+];
+
+function filterByProperty<T extends IdentifiableItem, K extends keyof T>(
+  items: T[],
+  key: K,
+  value: T[any]
+): T[] {
+  return items.filter(item => item[key] === value);
+}
+
+export const filteredBooksByAuthor = filterByProperty(books, 'author', {author:'Philip K. Dick'});
+
+export const filteredVideosByLength = filterByProperty(videos, 'length', '15');


### PR DESCRIPTION
keyof exercise - allowing to only pass the value type exact as field's value type we filter out