### PR TITLE
fix: advanced filtering challenge config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ dist
 
 #intellij
 .idea/
+
+# Config files should not be ignored
+!*.config.js

--- a/src/advanced-filtering/postcss.config.js
+++ b/src/advanced-filtering/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/advanced-filtering/tailwind.config.js
+++ b/src/advanced-filtering/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
Tailwind and postcss config files are missing because of the .gitignoring js files. Because of that, the example app was not looking like on the yt video.